### PR TITLE
refactor: remove objectMode argument as it is ignored by Duplex.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function build (fn, opts = {}) {
     // set it to null to not retain a reference to the promise
     res = null
   } else if (opts.enablePipelining && res) {
-    return Duplex.from({ writable: stream, readable: res, objectMode: true })
+    return Duplex.from({ writable: stream, readable: res })
   }
 
   return stream


### PR DESCRIPTION
https://github.com/nodejs/readable-stream/blob/v4.5.2/lib/internal/streams/duplexify.js#L63-L217

Duplex.from ignores keys other than readable and writable.