### PR TITLE
Update for v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - node-version: 14
-            os: windows-latest
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
   },
   "homepage": "https://github.com/pinojs/pino-abstract-transport#readme",
   "dependencies": {
-    "readable-stream": "^4.0.0",
-    "split2": "^4.0.0"
+    "readable-stream": "^4.5.2",
+    "split2": "^4.2.0"
   },
   "devDependencies": {
-    "@types/node": "^20.1.0",
-    "husky": "^9.0.6",
+    "@types/node": "^20.12.7",
+    "husky": "^9.0.11",
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tap": "^16.0.0",
-    "thread-stream": "^2.6.0",
+    "standard": "^17.1.0",
+    "tap": "^18.7.2",
+    "thread-stream": "^2.7.0",
     "tsd": "^0.31.0"
   },
   "tsd": {


### PR DESCRIPTION
This PR addresses issue #97 
This package uses `tap` for testing so no work there was needed.
I updated dependencies for the latest version and dropped node `14` and `16` from the CI

But please feel free to let me know if any work is needed. Thanks

@mcollina