### PR TITLE
Drop `readable-streams` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const metadata = Symbol.for('pino.metadata')
 const split = require('split2')
-const { Duplex } = require('readable-stream')
+const { Duplex } = require('stream')
 const { parentPort, workerData } = require('worker_threads')
 
 function createDeferred () {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/pinojs/pino-abstract-transport#readme",
   "dependencies": {
-    "readable-stream": "^4.0.0",
     "split2": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`stream.Duplex` has been available since Node ~~6.8.0~~ _0.9.4_

https://nodejs.org/api/stream.html#duplex-and-transform-streams