### PR TITLE
Drop Node 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [16, 18, 20]
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           - node-version: 14


### PR DESCRIPTION
Suggested in https://github.com/pinojs/pino-abstract-transport/pull/105#issuecomment-2306838220


Should I also add `"engines.node" ">=16"`?